### PR TITLE
Fix admin dashboard session handling

### DIFF
--- a/public/admin-login.php
+++ b/public/admin-login.php
@@ -2,7 +2,8 @@
 session_start();
 require_once __DIR__ . '/../app/db.php';
 
-$return = $_GET['return'] ?? '../public/index.php'; // default
+// After login, redirect to admin dashboard unless a specific return path is provided
+$return = $_GET['return'] ?? 'admin/dashboard.php';
 $errors = [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -20,12 +21,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         if ($user && password_verify($password, $user['password_hash'])) {
             session_regenerate_id(true);
-            $_SESSION['user_id']   = $user['id'];
-            $_SESSION['user_name'] = $user['name'];
-            $_SESSION['user_role'] = $user['role'] ?? 'user';
+            $_SESSION['admin_id']   = $user['id'];
+            $_SESSION['admin_name'] = $user['name'];
+            $_SESSION['admin_role'] = $user['role'] ?? 'user';
 
-            // safety: allow only internal relative paths starting with /
-            $returnUrl = (strpos($return, '/') === 0) ? $return : '../public/index.php';
+            // safety: allow only internal paths within this application
+            $returnUrl = (strpos($return, '/') === 0 || strpos($return, 'admin/') === 0)
+                ? $return
+                : 'admin/dashboard.php';
             header('Location: ' . $returnUrl);
             exit;
         } else {

--- a/public/admin-logout.php
+++ b/public/admin-logout.php
@@ -2,5 +2,6 @@
 session_start();
 $_SESSION = [];
 session_destroy();
-header('Location: ../public/admin-login.php');
+// Redirect back to admin login page
+header('Location: admin-login.php');
 exit;

--- a/public/admin/dashboard.php
+++ b/public/admin/dashboard.php
@@ -1,6 +1,9 @@
 <?php
-session_start();
+// Admin dashboard requires authentication and shared helpers
+require_once __DIR__ . '/../../app/admin_auth.php';
+require_once __DIR__ . '/../../app/csrf.php';
 require_once __DIR__ . '/../../app/db.php';
+require_once __DIR__ . '/../../app/config.php';
 ?>
 <!doctype html>
 <html>
@@ -15,7 +18,7 @@ require_once __DIR__ . '/../../app/db.php';
 <body>
     <div class="container py-4">
         <h3>Admin Dashboard</h3>
-        <p>Welcome, <?php echo htmlspecialchars($_SESSION['name']); ?> — Role: <?php echo htmlspecialchars($_SESSION['role']); ?></p>
+        <p>Welcome, <?php echo htmlspecialchars($_SESSION['admin_name'] ?? ''); ?> — Role: <?php echo htmlspecialchars($_SESSION['admin_role'] ?? ''); ?></p>
         <ul>
             <li><a href="projects-list.php">Manage Projects</a></li>
             <li><a href="blocks-list.php">Manage Blocks</a></li>


### PR DESCRIPTION
## Summary
- Add admin session includes and display admin name/role on dashboard
- Store admin session keys during login and redirect to dashboard
- Redirect logout to admin login page

## Testing
- `php -l public/admin/dashboard.php`
- `php -l public/admin-login.php`
- `php -l public/admin-logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68c559d134dc833185c077d5174445b2