### PR TITLE
Fix plot CSRF token handling and secure availability link

### DIFF
--- a/public/admin/plots-save.php
+++ b/public/admin/plots-save.php
@@ -1,6 +1,7 @@
 <?php
 // public/admin/plots-save.php
 require_once __DIR__ . '/../../app/admin_auth.php';
+require_once __DIR__ . '/../../app/csrf.php';
 require_once __DIR__ . '/../../app/db.php';
 require_once __DIR__ . '/../../app/config.php';
 
@@ -53,7 +54,7 @@ if ($id && empty($_POST)) {
 
 // POST handler
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (empty($_POST['token']) || ($_POST['token'] !== ($_SESSION['admin_csrf'] ?? ''))) {
+    if (!verify_admin_csrf($_POST['token'] ?? null)) {
         $errors[] = "Invalid token";
     }
 
@@ -126,7 +127,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php endif; ?>
 
         <form method="post">
-            <input type="hidden" name="token" value="<?= $_SESSION['admin_csrf'] ?? '' ?>">
+            <input type="hidden" name="token" value="<?= htmlspecialchars(admin_csrf_token()) ?>">
 
             <div class="form-group">
                 <label>Project</label>

--- a/public/project.php
+++ b/public/project.php
@@ -45,8 +45,14 @@ if (!$project) {
                         <h5>Check availability</h5>
                         <p>To see blocks and book plots, click below to continue.</p>
 
-                        <!-- Link to protected plots page. plots-grid.php will require login -->
-                        <a href="plots-grid.php?project_id=<?= urlencode($project['id']) ?>" class="btn btn-success btn-lg w-100">Check Availability</a>
+                        <!-- Link to protected plots page. If not logged in, send to login with return -->
+                        <?php
+                        $plotsUrl = 'plots-grid.php?project_id=' . urlencode($project['id']);
+                        $checkUrl = !empty($_SESSION['user_id'])
+                            ? $plotsUrl
+                            : 'admin-login.php?return=' . urlencode($plotsUrl);
+                        ?>
+                        <a href="<?= $checkUrl ?>" class="btn btn-success btn-lg w-100">Check Availability</a>
 
                         <hr>
                         <small class="text-muted">Already an admin? <a href="admin-login.php">Admin login</a></small>


### PR DESCRIPTION
## Summary
- generate and verify CSRF token properly when saving plots
- check login before sending users to plots grid

## Testing
- `php -l public/admin/plots-save.php`
- `php -l public/project.php`


------
https://chatgpt.com/codex/tasks/task_e_68c58477846c83319caca817cd7e88da